### PR TITLE
ReactDOMを使ったフラッシュメッセージ機能の実装

### DIFF
--- a/app/javascript/components/article_delete_button.jsx
+++ b/app/javascript/components/article_delete_button.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react"
+import ReactDOM from 'react-dom'
 import PropTypes from "prop-types"
 import classnames from 'classnames'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -51,6 +52,16 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
       })
     }
     
+    const flashMessage = () =>{
+      const element = (
+        <div>
+          <h1>記事を削除しました</h1>
+        </div>
+      )
+      ReactDOM.render(element, document.getElementById('root'))
+    }
+
+    
     return (
       <div className='popup'>
         <div className='popup_inner text-center'>
@@ -66,7 +77,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
               className='btn btn-danger' 
               onClick={ () => deleteArticle()
                               .then(hideModal)
-                              .then(reloadPage) } >
+                              .then(reloadPage)
+                              .then(flashMessage)} >
               削除
             </button>
           </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,7 @@
     <% flash.each do |message_type, message| %>
       <div class='alert alert-<%= message_type %>'><%= message %></div>
     <% end %>
+    <div id="root"></div>
     <%= yield %>
   </body>
 </html>

--- a/public/packs/manifest.json
+++ b/public/packs/manifest.json
@@ -1,6 +1,6 @@
 {
-  "application.js": "/packs/application-425022152ac2a2c7a667.js",
-  "application.js.map": "/packs/application-425022152ac2a2c7a667.js.map",
-  "server_rendering.js": "/packs/server_rendering-ca40fa5a6bc64d271f92.js",
-  "server_rendering.js.map": "/packs/server_rendering-ca40fa5a6bc64d271f92.js.map"
+  "application.js": "/packs/application-93cf74278efaf3ca1bee.js",
+  "application.js.map": "/packs/application-93cf74278efaf3ca1bee.js.map",
+  "server_rendering.js": "/packs/server_rendering-9157a33f7f0cbf2de0f9.js",
+  "server_rendering.js.map": "/packs/server_rendering-9157a33f7f0cbf2de0f9.js.map"
 }


### PR DESCRIPTION
◼️実現したいこと
記事削除処理の後、ページをリロードして再描画完了後に、
「記事を削除しました」というフラッシュメッセージを表示したいです。

◼️試したこと
ページの再描画が完了した後に、
application.html.erbの20行目の箇所に、
article_delete_button.jsx 55行目からのflashMessage関数で
フラッシュメッセージのDOMをrenderしようと試みました。

◼️困っていること
この実装だと、ページをリロードしてから再描画されるまでの間に
メッセージが表示されてしまい、再描画完了時には消えてしまっていました。

ご指導の程、よろしくお願いいたします。