### PR TITLE
Delete <div id=root> tag for ReactDOM

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,6 @@
     <% flash.each do |message_type, message| %>
       <div class='alert alert-<%= message_type %>'><%= message %></div>
     <% end %>
-    <div id="root"></div>
     <%= yield %>
   </body>
 </html>


### PR DESCRIPTION
◼️変更点
・Reactでのフラッシュメッセージ実装用に作成していた<div>タグを削除