### PR TITLE
Add display order chnage system when looged in

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -9,6 +9,7 @@ class LikesController < ApplicationController
     @article = Article.find(params[:liked_article_id])
     @like = current_user.add_like(@article)
     @like_count = Like.where(liked_article_id: @article.id).count
+    @article.update(like_counts: @like_count)
 
     respond_to do |format|
       format.html { redirect_to @article }
@@ -20,6 +21,7 @@ class LikesController < ApplicationController
     @article = Like.find(params[:id]).liked_article
     current_user.remove_like(@article)
     @like_count = Like.where(liked_article_id: @article.id).count
+    @article.update(like_counts: @like_count)
 
     respond_to do |format|
       format.html { redirect_to @article }

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -2,6 +2,28 @@
 
 class StaticPagesController < ApplicationController
   def home
-    @articles = Article.all
+    if current_user
+      current_user.update(order_option: params[:option]) if params[:option]
+      display_order_change(current_user.order_option)
+    else
+      # notLoginOption テーブル（ログインしていない時に使用したいデータを保存するDB）
+      # のorder_option を参照する
+      @articles = Article.order(created_at: :desc)
+    end
+
+    respond_to do |format|
+      format.html { render 'static_pages/home' }
+      format.json { render json: nil }
+    end
+  end
+
+  private
+
+  def display_order_change(option)
+    if option.zero?
+      @articles = Article.order(created_at: :desc)
+    elsif option == 1
+      @articles = Article.order(like_counts: :desc)
+    end
   end
 end

--- a/app/javascript/components/changing_display_order_button.jsx
+++ b/app/javascript/components/changing_display_order_button.jsx
@@ -5,17 +5,53 @@ function ChangingDisplayOrderButton(){
   const primaryButton = classnames('d-inline-block p-2 mx-2 btn btn-primary')
   const darkButton = classnames('d-inline-block p-2 mx-2 btn btn-secondary')
   
+  const orderByCreatedAtDesk = () =>{
+    $.ajax({
+      type: 'POST',
+      url: `/`,
+      dataType: 'json',
+      contentType: 'application/json',
+      data: JSON.stringify({
+        option: 0
+      }),
+      beforeSend: function(xhr) {
+        xhr.setRequestHeader('X-CSRF-Token', $('meta[name="csrf-token"]').attr('content'))
+      }
+    }).then((response) => {
+      window.location.reload(true)
+    })
+  }
+  
+  const orderByCreatedAtAsk = () =>{
+    $.ajax({
+      type: 'POST',
+      url: `/`,
+      dataType: 'json',
+      contentType: 'application/json',
+      data: JSON.stringify({
+        option: 1
+      }),
+      beforeSend: function(xhr) {
+        xhr.setRequestHeader('X-CSRF-Token', $('meta[name="csrf-token"]').attr('content'))
+      }
+    }).then((response) => {
+      window.location.reload(true)
+    })
+  }
+  
   return(
     <div>
       <div className = 'form-group row justify-content-center'>
         <div>
           <div
             className={ primaryButton }
+            onClick={ () => orderByCreatedAtDesk() }
           >
             新しい投稿順
           </div>
           <div
             className={ darkButton }
+            onClick={ () => orderByCreatedAtAsk() }
           >
             いいね多い順
           </div>

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -14,7 +14,6 @@ class Article < ApplicationRecord
   has_many :like_users, through: :liked, source: :like_user
 
   belongs_to :user
-  default_scope { order(created_at: :desc) }
 
   # ----- バリデーション -----
   validates :sweet_name, presence: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   delete '/logout', to: 'sessions#destroy'
 
   root 'static_pages#home'
+  post '/', to: 'static_pages#home'
 
   resources :users do
     get 'deactivate', on: :member

--- a/db/migrate/20191216102503_add_column_to_user.rb
+++ b/db/migrate/20191216102503_add_column_to_user.rb
@@ -1,0 +1,5 @@
+class AddColumnToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :order_option, :integer, null: false, default: 0 
+  end
+end

--- a/db/migrate/20191221053300_add_like_counts_to_articles.rb
+++ b/db/migrate/20191221053300_add_like_counts_to_articles.rb
@@ -1,0 +1,5 @@
+class AddLikeCountsToArticles < ActiveRecord::Migration[5.1]
+  def change
+    add_column :articles, :like_counts, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191103080505) do
+ActiveRecord::Schema.define(version: 20191221053300) do
 
   create_table "articles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "content"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 20191103080505) do
     t.string "genre"
     t.string "image"
     t.string "sweet_name"
+    t.integer "like_counts", default: 0, null: false
     t.index ["user_id", "created_at"], name: "index_articles_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
@@ -54,6 +55,7 @@ ActiveRecord::Schema.define(version: 20191103080505) do
     t.string "remember_digest"
     t.string "image"
     t.datetime "last_access_time", default: "1900-01-01 00:00:00"
+    t.integer "order_option", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/public/packs/manifest.json
+++ b/public/packs/manifest.json
@@ -1,6 +1,6 @@
 {
-  "application.js": "/packs/application-645fac33821db295e3c2.js",
-  "application.js.map": "/packs/application-645fac33821db295e3c2.js.map",
-  "server_rendering.js": "/packs/server_rendering-0f46a4b6cc935c92c785.js",
-  "server_rendering.js.map": "/packs/server_rendering-0f46a4b6cc935c92c785.js.map"
+  "application.js": "/packs/application-fbb3207243eabd4beb8d.js",
+  "application.js.map": "/packs/application-fbb3207243eabd4beb8d.js.map",
+  "server_rendering.js": "/packs/server_rendering-abaf79364ed5afdb6611.js",
+  "server_rendering.js.map": "/packs/server_rendering-abaf79364ed5afdb6611.js.map"
 }

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -26,10 +26,4 @@ RSpec.describe Article, type: :model do
       end
     end
   end
-
-  context '記事の順番'
-  example '投稿時刻の降順になっているか' do
-    create_article(user)
-    expect(user.articles.first.content).to eq '5番目の投稿'
-  end
 end


### PR DESCRIPTION
◼️ユーザーログイン時の記事表示順（新しい投稿順、いいね多い順）の切り替え機能追加

・ユーザーごとに表示切り換え用オプションカラムの追加
・各記事のいいね数を保存するカラムをArticleテーブルに追加
・ボタンを押下した時にオプションのパラメータを渡す機能を実装
・オプションにより記事のソート順を変更する機能を追加
・記事の新しい順でdefault_scopeする必要がなくなったため、削除
・上記確認用のテストを削除