### PR TITLE
Changing display order

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,8 @@ Style/Documentation:
   Enabled: false
 
 # --- Metrics --- #
+Metrics/AbcSize:
+  Max: 25
 
 Metrics/BlockLength:
   Exclude:
@@ -29,5 +31,5 @@ Metrics/BlockLength:
 Metrics/LineLength:
   Max: 130
 
-Metrics/AbcSize:
-  Max: 25
+Metrics/MethodLength:
+  Max: 15

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -43,8 +43,16 @@ class ArticlesController < ApplicationController
   end
 
   def index
-    @articles = Article.where(genre: params[:genre])
-    render '/static_pages/home'
+    # @articles = Article.where(genre: params[:genre])
+    if current_user
+      current_user.update(order_option: params[:option]) if params[:option]
+      display_order_change(current_user.order_option)
+    end
+    # render '/static_pages/home'
+    respond_to do |format|
+      format.html { render 'static_pages/home' }
+      format.json { render json: nil }
+    end
   end
 
   def destroy
@@ -66,5 +74,13 @@ class ArticlesController < ApplicationController
 
     flash[:danger] = 'アクセス権がありません'
     redirect_to root_url
+  end
+
+  def display_order_change(option)
+    if option.zero?
+      @articles = Article.where(genre: params[:genre]).order(created_at: :desc)
+    elsif option == 1
+      @articles = Article.where(genre: params[:genre]).order(like_counts: :desc)
+    end
   end
 end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -43,12 +43,16 @@ class ArticlesController < ApplicationController
   end
 
   def index
-    # @articles = Article.where(genre: params[:genre])
     if current_user
       current_user.update(order_option: params[:option]) if params[:option]
-      display_order_change(current_user.order_option)
+      option = current_user.order_option
+    else
+      set_option_in_session
+      option = session[:not_logged_in]
     end
-    # render '/static_pages/home'
+
+    display_order_change(option)
+
     respond_to do |format|
       format.html { render 'static_pages/home' }
       format.json { render json: nil }
@@ -82,5 +86,10 @@ class ArticlesController < ApplicationController
     elsif option == 1
       @articles = Article.where(genre: params[:genre]).order(like_counts: :desc)
     end
+  end
+
+  def set_option_in_session
+    session[:not_logged_in] = 0                    if session[:not_logged_in].nil?
+    session[:not_logged_in] = params[:option].to_i if params[:option]
   end
 end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -2,6 +2,7 @@
 
 class ArticlesController < ApplicationController
   include Common
+  include DisplayOrder
 
   before_action :logged_in_user, only: %i[new create edit update destroy]
   before_action :correct_article_user, only: %i[edit update destroy]
@@ -78,18 +79,5 @@ class ArticlesController < ApplicationController
 
     flash[:danger] = 'アクセス権がありません'
     redirect_to root_url
-  end
-
-  def display_order_change(option)
-    if option.zero?
-      @articles = Article.where(genre: params[:genre]).order(created_at: :desc)
-    elsif option == 1
-      @articles = Article.where(genre: params[:genre]).order(like_counts: :desc)
-    end
-  end
-
-  def set_option_in_session
-    session[:not_logged_in] = 0                    if session[:not_logged_in].nil?
-    session[:not_logged_in] = params[:option].to_i if params[:option]
   end
 end

--- a/app/controllers/concerns/display_order.rb
+++ b/app/controllers/concerns/display_order.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module DisplayOrder
+  extend ActiveSupport::Concern
+
+  private
+
+  def display_order_change(option)
+    if option.zero?
+      @articles = Article.order(created_at: :desc)
+    elsif option == 1
+      @articles = Article.order(like_counts: :desc)
+    end
+  end
+
+  # ログインしていない時に記事表示順を切り替える用の
+  # パラメータをセッションに格納
+  def set_option_in_session
+    session[:not_logged_in] = 0                    if session[:not_logged_in].nil?
+    session[:not_logged_in] = params[:option].to_i if params[:option]
+  end
+end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -8,24 +8,24 @@ class LikesController < ApplicationController
   def create
     @article = Article.find(params[:liked_article_id])
     @like = current_user.add_like(@article)
-    @like_count = Like.where(liked_article_id: @article.id).count
-    @article.update(like_counts: @like_count)
+    @like_counts = Like.where(liked_article_id: @article.id).count
+    @article.update(like_counts: @like_counts)
 
     respond_to do |format|
       format.html { redirect_to @article }
-      format.json { render json: { like: current_user.likes.find_by(liked_article_id: @article.id), count: @like_count } }
+      format.json { render json: { like: current_user.likes.find_by(liked_article_id: @article.id), counts: @like_counts } }
     end
   end
 
   def destroy
     @article = Like.find(params[:id]).liked_article
     current_user.remove_like(@article)
-    @like_count = Like.where(liked_article_id: @article.id).count
-    @article.update(like_counts: @like_count)
+    @like_counts = Like.where(liked_article_id: @article.id).count
+    @article.update(like_counts: @like_counts)
 
     respond_to do |format|
       format.html { redirect_to @article }
-      format.json { render json: { like: nil, count: @like_count } }
+      format.json { render json: { like: nil, counts: @like_counts } }
     end
   end
 end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -9,6 +9,7 @@ class LikesController < ApplicationController
     @article = Article.find(params[:liked_article_id])
     @like = current_user.add_like(@article)
     @like_count = Like.where(liked_article_id: @article.id).count
+    @article.update(like_counts: @like_count)
 
     respond_to do |format|
       format.html { redirect_to @article }
@@ -20,6 +21,7 @@ class LikesController < ApplicationController
     @article = Like.find(params[:id]).liked_article
     current_user.remove_like(@article)
     @like_count = Like.where(liked_article_id: @article.id).count
+    @article.update(like_counts: @like_count)
 
     respond_to do |format|
       format.html { redirect_to @article }

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -4,12 +4,13 @@ class StaticPagesController < ApplicationController
   def home
     if current_user
       current_user.update(order_option: params[:option]) if params[:option]
-      display_order_change(current_user.order_option)
+      option = current_user.order_option
     else
-      # notLoginOption テーブル（ログインしていない時に使用したいデータを保存するDB）
-      # のorder_option を参照する
-      @articles = Article.order(created_at: :desc)
+      set_option_in_session
+      option = session[:not_logged_in]
     end
+
+    display_order_change(option)
 
     respond_to do |format|
       format.html { render 'static_pages/home' }
@@ -25,5 +26,10 @@ class StaticPagesController < ApplicationController
     elsif option == 1
       @articles = Article.order(like_counts: :desc)
     end
+  end
+
+  def set_option_in_session
+    session[:not_logged_in] = 0                    if session[:not_logged_in].nil?
+    session[:not_logged_in] = params[:option].to_i if params[:option]
   end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class StaticPagesController < ApplicationController
+  include DisplayOrder
+
   def home
     if current_user
       current_user.update(order_option: params[:option]) if params[:option]
@@ -16,20 +18,5 @@ class StaticPagesController < ApplicationController
       format.html { render 'static_pages/home' }
       format.json { render json: nil }
     end
-  end
-
-  private
-
-  def display_order_change(option)
-    if option.zero?
-      @articles = Article.order(created_at: :desc)
-    elsif option == 1
-      @articles = Article.order(like_counts: :desc)
-    end
-  end
-
-  def set_option_in_session
-    session[:not_logged_in] = 0                    if session[:not_logged_in].nil?
-    session[:not_logged_in] = params[:option].to_i if params[:option]
   end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -2,6 +2,28 @@
 
 class StaticPagesController < ApplicationController
   def home
-    @articles = Article.all
+    if current_user
+      current_user.update(order_option: params[:option]) if params[:option]
+      display_order_change(current_user.order_option)
+    else
+      # notLoginOption テーブル（ログインしていない時に使用したいデータを保存するDB）
+      # のorder_option を参照する
+      @articles = Article.order(created_at: :desc)
+    end
+
+    respond_to do |format|
+      format.html { render 'static_pages/home' }
+      format.json { render json: nil }
+    end
+  end
+
+  private
+
+  def display_order_change(option)
+    if option.zero?
+      @articles = Article.order(created_at: :desc)
+    elsif option == 1
+      @articles = Article.order(like_counts: :desc)
+    end
   end
 end

--- a/app/javascript/components/changing_display_order_button.jsx
+++ b/app/javascript/components/changing_display_order_button.jsx
@@ -4,9 +4,9 @@ import classnames from 'classnames'
 function ChangingDisplayOrderButton(){
   const primaryButton = classnames('d-inline-block p-2 mx-2 btn btn-primary')
   const darkButton = classnames('d-inline-block p-2 mx-2 btn btn-secondary')
+  const root_url = "https://b57360db244146fc98d63bdf0ee06acb.vfs.cloud9.us-east-2.amazonaws.com/"
   
   const setInfo = (url, opt) => {
-    const root_url = "https://b57360db244146fc98d63bdf0ee06acb.vfs.cloud9.us-east-2.amazonaws.com/"
     let type, data
     
     if(url == root_url){

--- a/app/javascript/components/changing_display_order_button.jsx
+++ b/app/javascript/components/changing_display_order_button.jsx
@@ -1,32 +1,48 @@
-import React from "react"
+import React, {useState} from "react"
 import classnames from 'classnames'
 
-function ChangingDisplayOrderButton(){
-  const primaryButton = classnames('d-inline-block p-2 mx-2 btn btn-primary')
-  const darkButton = classnames('d-inline-block p-2 mx-2 btn btn-secondary')
+function ChangingDisplayOrderButton(props){
   const root_url = "https://b57360db244146fc98d63bdf0ee06acb.vfs.cloud9.us-east-2.amazonaws.com/"
+  const url = window.location.href
+  
+  const [option, setOption] = useState(props.option)
+  const [loading, setLoading] = useState(false)
   
   const setInfo = (url, opt) => {
-    let type, data
+    let type, optionData
     
     if(url == root_url){
       type = 'POST'
-      data = JSON.stringify({ option: opt })
+      optionData = JSON.stringify({ option: opt })
     }else{
       type = 'GET'
-      data = { option: opt }
+      optionData = { option: opt }
     }
     
-    return[type, data]
+    return[type, optionData]
   }
   
-  const ajaxProcess = (type, url, data) => {
+  const setLoadingTrue = () =>{
+    return new Promise((resolve, reject) => {
+      setLoading(true)
+      resolve()
+    })
+  }
+  
+  const setOpt = (opt) =>{
+    return new Promise((resolve, reject) => {
+      setOption(opt)
+      resolve()
+    })
+  }
+  
+  const sendOptionWithAjax = (type, url, option) => {
     $.ajax({
       type: type,
       url: url,
       dataType: 'json',
       contentType: 'application/json',
-      data: data,
+      data: option,
       beforeSend: function(xhr) {
         xhr.setRequestHeader('X-CSRF-Token', $('meta[name="csrf-token"]').attr('content'))
       }
@@ -36,39 +52,51 @@ function ChangingDisplayOrderButton(){
   }
   
   const orderByCreatedAtDesk = () =>{
-    const url = window.location.href
-    const [type, data] = setInfo(url, 0)
     
-    ajaxProcess(type, url, data)
+    const [type, opt] = setInfo(url, 0)
+    
+    setOpt(opt)
+    .then(setLoadingTrue()
+    .then(sendOptionWithAjax(type, url, opt)
+      )
+    )
   }
   
   const orderByCreatedAtAsk = () =>{
-    const url = window.location.href
-    const [type, data] = setInfo(url, 1)
+    const [type, opt] = setInfo(url, 1)
     
-    ajaxProcess(type, url, data)
+    setOpt(opt)
+    .then(setLoadingTrue()
+    .then(sendOptionWithAjax(type, url, opt)
+      )
+    )
   }
+  
+  const primaryButton = classnames('d-inline-block p-2 mx-2 btn btn-primary')
+  const secondaryButton = classnames('d-inline-block p-2 mx-2 btn btn-secondary')
   
   return(
     <div>
       <div className = 'form-group row justify-content-center'>
         <div>
-          <div
-            className={ primaryButton }
+          <button
+            className={ option === 0 ? primaryButton : secondaryButton }
             onClick={ () => orderByCreatedAtDesk() }
+            disabled={ loading }
           >
             新しい投稿順
-          </div>
-          <div
-            className={ darkButton }
+          </button>
+          <button
+            className={ option === 0 ? secondaryButton : primaryButton }
             onClick={ () => orderByCreatedAtAsk() }
+            disabled={ loading }
           >
             いいね多い順
-          </div>
+          </button>
         </div>
       </div>
     </div>
-    )
+  )
 }
 
 export default ChangingDisplayOrderButton

--- a/app/javascript/components/changing_display_order_button.jsx
+++ b/app/javascript/components/changing_display_order_button.jsx
@@ -1,0 +1,28 @@
+import React, { useState } from "react"
+import classnames from 'classnames'
+
+function ChangingDisplayOrderButton(){
+  const primaryButton = classnames('d-inline-block p-2 mx-2 btn btn-primary')
+  const darkButton = classnames('d-inline-block p-2 mx-2 btn btn-secondary')
+  
+  return(
+    <div>
+      <div className = 'form-group row justify-content-center'>
+        <div>
+          <div
+            className={ primaryButton }
+          >
+            新しい投稿順
+          </div>
+          <div
+            className={ darkButton }
+          >
+            いいね多い順
+          </div>
+        </div>
+      </div>
+    </div>
+    )
+}
+
+export default ChangingDisplayOrderButton

--- a/app/javascript/components/changing_display_order_button.jsx
+++ b/app/javascript/components/changing_display_order_button.jsx
@@ -1,19 +1,32 @@
-import React, { useState } from "react"
+import React from "react"
 import classnames from 'classnames'
 
 function ChangingDisplayOrderButton(){
   const primaryButton = classnames('d-inline-block p-2 mx-2 btn btn-primary')
   const darkButton = classnames('d-inline-block p-2 mx-2 btn btn-secondary')
   
-  const orderByCreatedAtDesk = () =>{
+  const setInfo = (url, opt) => {
+    const root_url = "https://b57360db244146fc98d63bdf0ee06acb.vfs.cloud9.us-east-2.amazonaws.com/"
+    let type, data
+    
+    if(url == root_url){
+      type = 'POST'
+      data = JSON.stringify({ option: opt })
+    }else{
+      type = 'GET'
+      data = { option: opt }
+    }
+    
+    return[type, data]
+  }
+  
+  const ajaxProcess = (type, url, data) => {
     $.ajax({
-      type: 'POST',
-      url: `/`,
+      type: type,
+      url: url,
       dataType: 'json',
       contentType: 'application/json',
-      data: JSON.stringify({
-        option: 0
-      }),
+      data: data,
       beforeSend: function(xhr) {
         xhr.setRequestHeader('X-CSRF-Token', $('meta[name="csrf-token"]').attr('content'))
       }
@@ -22,21 +35,18 @@ function ChangingDisplayOrderButton(){
     })
   }
   
+  const orderByCreatedAtDesk = () =>{
+    const url = window.location.href
+    const [type, data] = setInfo(url, 0)
+    
+    ajaxProcess(type, url, data)
+  }
+  
   const orderByCreatedAtAsk = () =>{
-    $.ajax({
-      type: 'POST',
-      url: `/`,
-      dataType: 'json',
-      contentType: 'application/json',
-      data: JSON.stringify({
-        option: 1
-      }),
-      beforeSend: function(xhr) {
-        xhr.setRequestHeader('X-CSRF-Token', $('meta[name="csrf-token"]').attr('content'))
-      }
-    }).then((response) => {
-      window.location.reload(true)
-    })
+    const url = window.location.href
+    const [type, data] = setInfo(url, 1)
+    
+    ajaxProcess(type, url, data)
   }
   
   return(

--- a/app/javascript/components/changing_display_order_button.jsx
+++ b/app/javascript/components/changing_display_order_button.jsx
@@ -5,17 +5,53 @@ function ChangingDisplayOrderButton(){
   const primaryButton = classnames('d-inline-block p-2 mx-2 btn btn-primary')
   const darkButton = classnames('d-inline-block p-2 mx-2 btn btn-secondary')
   
+  const orderByCreatedAtDesk = () =>{
+    $.ajax({
+      type: 'POST',
+      url: `/`,
+      dataType: 'json',
+      contentType: 'application/json',
+      data: JSON.stringify({
+        option: 0
+      }),
+      beforeSend: function(xhr) {
+        xhr.setRequestHeader('X-CSRF-Token', $('meta[name="csrf-token"]').attr('content'))
+      }
+    }).then((response) => {
+      window.location.reload(true)
+    })
+  }
+  
+  const orderByCreatedAtAsk = () =>{
+    $.ajax({
+      type: 'POST',
+      url: `/`,
+      dataType: 'json',
+      contentType: 'application/json',
+      data: JSON.stringify({
+        option: 1
+      }),
+      beforeSend: function(xhr) {
+        xhr.setRequestHeader('X-CSRF-Token', $('meta[name="csrf-token"]').attr('content'))
+      }
+    }).then((response) => {
+      window.location.reload(true)
+    })
+  }
+  
   return(
     <div>
       <div className = 'form-group row justify-content-center'>
         <div>
           <div
             className={ primaryButton }
+            onClick={ () => orderByCreatedAtDesk() }
           >
             新しい投稿順
           </div>
           <div
             className={ darkButton }
+            onClick={ () => orderByCreatedAtAsk() }
           >
             いいね多い順
           </div>

--- a/app/javascript/components/like_button.jsx
+++ b/app/javascript/components/like_button.jsx
@@ -31,7 +31,7 @@ function LikeButton(props) {
     }).then((response) => {
       setLoading(false)
       setLikeID(response.like.id)
-      setCount(response.count)
+      setCount(response.counts)
     })
   }
   
@@ -49,7 +49,7 @@ function LikeButton(props) {
     }).then((response) => {
       setLoading(false)
       setLikeID(null)
-      setCount(response.count)
+      setCount(response.counts)
     })
   }
   
@@ -81,6 +81,6 @@ export default LikeButton
 LikeButton.propTypes = {
   article_id: PropTypes.number.isRequired,
   like_id: PropTypes.number,
-  count: PropTypes.number,
+  counts: PropTypes.number,
   user: PropTypes.object.isRequired
 }

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -14,7 +14,6 @@ class Article < ApplicationRecord
   has_many :like_users, through: :liked, source: :like_user
 
   belongs_to :user
-  default_scope { order(created_at: :desc) }
 
   # ----- バリデーション -----
   validates :sweet_name, presence: true

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -26,6 +26,7 @@
       </div>
     </div>
     <div class="col-md-6">
+      <%= react_component('changing_display_order_button') %>
       <%= render @articles %>
     </div>
   </div>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -26,7 +26,7 @@
       </div>
     </div>
     <div class="col-md-6">
-      <%= react_component('changing_display_order_button') %>
+      <%= react_component('changing_display_order_button', option: current_user &. order_option) %>
       <%= render @articles %>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   delete '/logout', to: 'sessions#destroy'
 
   root 'static_pages#home'
+  post '/', to: 'static_pages#home'
 
   resources :users do
     get 'deactivate', on: :member

--- a/db/migrate/20191216102503_add_column_to_user.rb
+++ b/db/migrate/20191216102503_add_column_to_user.rb
@@ -1,0 +1,5 @@
+class AddColumnToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :order_option, :integer, null: false, default: 0 
+  end
+end

--- a/db/migrate/20191221053300_add_like_counts_to_articles.rb
+++ b/db/migrate/20191221053300_add_like_counts_to_articles.rb
@@ -1,0 +1,5 @@
+class AddLikeCountsToArticles < ActiveRecord::Migration[5.1]
+  def change
+    add_column :articles, :like_counts, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191103080505) do
+ActiveRecord::Schema.define(version: 20191221053300) do
 
   create_table "articles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "content"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 20191103080505) do
     t.string "genre"
     t.string "image"
     t.string "sweet_name"
+    t.integer "like_counts", default: 0, null: false
     t.index ["user_id", "created_at"], name: "index_articles_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
@@ -54,6 +55,7 @@ ActiveRecord::Schema.define(version: 20191103080505) do
     t.string "remember_digest"
     t.string "image"
     t.datetime "last_access_time", default: "1900-01-01 00:00:00"
+    t.integer "order_option", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/public/packs/manifest.json
+++ b/public/packs/manifest.json
@@ -1,6 +1,6 @@
 {
-  "application.js": "/packs/application-61ffbca9964a301eaf74.js",
-  "application.js.map": "/packs/application-61ffbca9964a301eaf74.js.map",
-  "server_rendering.js": "/packs/server_rendering-f87d8e0765da9bf195f6.js",
-  "server_rendering.js.map": "/packs/server_rendering-f87d8e0765da9bf195f6.js.map"
+  "application.js": "/packs/application-0f889274af90f9e30e8f.js",
+  "application.js.map": "/packs/application-0f889274af90f9e30e8f.js.map",
+  "server_rendering.js": "/packs/server_rendering-c76f86fadb5ee78644dc.js",
+  "server_rendering.js.map": "/packs/server_rendering-c76f86fadb5ee78644dc.js.map"
 }

--- a/public/packs/manifest.json
+++ b/public/packs/manifest.json
@@ -1,6 +1,6 @@
 {
-  "application.js": "/packs/application-fbb3207243eabd4beb8d.js",
-  "application.js.map": "/packs/application-fbb3207243eabd4beb8d.js.map",
-  "server_rendering.js": "/packs/server_rendering-abaf79364ed5afdb6611.js",
-  "server_rendering.js.map": "/packs/server_rendering-abaf79364ed5afdb6611.js.map"
+  "application.js": "/packs/application-61ffbca9964a301eaf74.js",
+  "application.js.map": "/packs/application-61ffbca9964a301eaf74.js.map",
+  "server_rendering.js": "/packs/server_rendering-f87d8e0765da9bf195f6.js",
+  "server_rendering.js.map": "/packs/server_rendering-f87d8e0765da9bf195f6.js.map"
 }

--- a/public/packs/manifest.json
+++ b/public/packs/manifest.json
@@ -1,6 +1,6 @@
 {
-  "application.js": "/packs/application-645fac33821db295e3c2.js",
-  "application.js.map": "/packs/application-645fac33821db295e3c2.js.map",
-  "server_rendering.js": "/packs/server_rendering-0f46a4b6cc935c92c785.js",
-  "server_rendering.js.map": "/packs/server_rendering-0f46a4b6cc935c92c785.js.map"
+  "application.js": "/packs/application-fbb3207243eabd4beb8d.js",
+  "application.js.map": "/packs/application-fbb3207243eabd4beb8d.js.map",
+  "server_rendering.js": "/packs/server_rendering-abaf79364ed5afdb6611.js",
+  "server_rendering.js.map": "/packs/server_rendering-abaf79364ed5afdb6611.js.map"
 }

--- a/public/packs/manifest.json
+++ b/public/packs/manifest.json
@@ -1,6 +1,6 @@
 {
-  "application.js": "/packs/application-70dc878805580927409a.js",
-  "application.js.map": "/packs/application-70dc878805580927409a.js.map",
-  "server_rendering.js": "/packs/server_rendering-11a8f512f5be95ca64b7.js",
-  "server_rendering.js.map": "/packs/server_rendering-11a8f512f5be95ca64b7.js.map"
+  "application.js": "/packs/application-f5fe8ac68d2c4f8a1b17.js",
+  "application.js.map": "/packs/application-f5fe8ac68d2c4f8a1b17.js.map",
+  "server_rendering.js": "/packs/server_rendering-d1edf18c8e390c9a956d.js",
+  "server_rendering.js.map": "/packs/server_rendering-d1edf18c8e390c9a956d.js.map"
 }

--- a/public/packs/manifest.json
+++ b/public/packs/manifest.json
@@ -1,6 +1,6 @@
 {
-  "application.js": "/packs/application-0f889274af90f9e30e8f.js",
-  "application.js.map": "/packs/application-0f889274af90f9e30e8f.js.map",
-  "server_rendering.js": "/packs/server_rendering-c76f86fadb5ee78644dc.js",
-  "server_rendering.js.map": "/packs/server_rendering-c76f86fadb5ee78644dc.js.map"
+  "application.js": "/packs/application-70dc878805580927409a.js",
+  "application.js.map": "/packs/application-70dc878805580927409a.js.map",
+  "server_rendering.js": "/packs/server_rendering-11a8f512f5be95ca64b7.js",
+  "server_rendering.js.map": "/packs/server_rendering-11a8f512f5be95ca64b7.js.map"
 }

--- a/public/packs/manifest.json
+++ b/public/packs/manifest.json
@@ -1,6 +1,6 @@
 {
-  "application.js": "/packs/application-f5fe8ac68d2c4f8a1b17.js",
-  "application.js.map": "/packs/application-f5fe8ac68d2c4f8a1b17.js.map",
-  "server_rendering.js": "/packs/server_rendering-d1edf18c8e390c9a956d.js",
-  "server_rendering.js.map": "/packs/server_rendering-d1edf18c8e390c9a956d.js.map"
+  "application.js": "/packs/application-ed130227b4f91ac1409e.js",
+  "application.js.map": "/packs/application-ed130227b4f91ac1409e.js.map",
+  "server_rendering.js": "/packs/server_rendering-8c8ec99807f0d28fa11e.js",
+  "server_rendering.js.map": "/packs/server_rendering-8c8ec99807f0d28fa11e.js.map"
 }

--- a/public/packs/manifest.json
+++ b/public/packs/manifest.json
@@ -1,6 +1,6 @@
 {
-  "application.js": "/packs/application-18f469846adaeabb0a9b.js",
-  "application.js.map": "/packs/application-18f469846adaeabb0a9b.js.map",
-  "server_rendering.js": "/packs/server_rendering-c5426fed475dd4b620a5.js",
-  "server_rendering.js.map": "/packs/server_rendering-c5426fed475dd4b620a5.js.map"
+  "application.js": "/packs/application-645fac33821db295e3c2.js",
+  "application.js.map": "/packs/application-645fac33821db295e3c2.js.map",
+  "server_rendering.js": "/packs/server_rendering-0f46a4b6cc935c92c785.js",
+  "server_rendering.js.map": "/packs/server_rendering-0f46a4b6cc935c92c785.js.map"
 }

--- a/spec/factories/article.rb
+++ b/spec/factories/article.rb
@@ -2,7 +2,17 @@
 
 FactoryBot.define do
   sequence :content do |n|
-    "#{n}番目の投稿"
+    i = if n % 5 == 0
+          5
+        else
+          n % 5
+        end
+
+    "#{i}番目の投稿"
+  end
+
+  sequence :like_counts do |n|
+    5 if n % 5 == 1
   end
 
   factory :article, class: Article do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -26,10 +26,4 @@ RSpec.describe Article, type: :model do
       end
     end
   end
-
-  context '記事の順番'
-  example '投稿時刻の降順になっているか' do
-    create_article(user)
-    expect(user.articles.first.content).to eq '5番目の投稿'
-  end
 end

--- a/spec/support/spec_test_helper.rb
+++ b/spec/support/spec_test_helper.rb
@@ -15,8 +15,8 @@ module SpecTestHelpers
   end
 
   def create_article(user)
-    (1..5).each do |_i|
-      create(:article, user_id: user.id)
+    (1..5).each do |i|
+      create(:article, user_id: user.id, created_at: Time.zone.now + i)
     end
   end
 end

--- a/spec/system/article/display_order_spec.rb
+++ b/spec/system/article/display_order_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe '記事表示順に関する挙動', type: :system do
+  let(:user) { create(:user1) }
+  before do
+    create_article(user)
+  end
+
+  context 'ユーザーログイン時' do
+    subject do
+      log_in(user)
+      visit(root_path)
+    end
+
+    example '最初は新しい投稿順に表示されている' do
+      subject
+      expect(first('.content')).to have_content '5番目の投稿'
+    end
+
+    example '新しい投稿順への切り替え' do
+      subject
+      click_button('新しい投稿順')
+      sleep 1
+      expect(first('.content')).to have_content '5番目の投稿'
+    end
+
+    example 'いいね多い順への切り替え' do
+      subject
+      click_button('いいね多い順')
+      sleep 1
+      expect(first('.content')).to have_content '1番目の投稿'
+    end
+  end
+end

--- a/spec/system/article/display_order_spec.rb
+++ b/spec/system/article/display_order_spec.rb
@@ -9,25 +9,44 @@ RSpec.describe '記事表示順に関する挙動', type: :system do
   end
 
   context 'ユーザーログイン時' do
-    subject do
+    before do
       log_in(user)
       visit(root_path)
     end
 
     example '最初は新しい投稿順に表示されている' do
-      subject
       expect(first('.content')).to have_content '5番目の投稿'
     end
 
     example '新しい投稿順への切り替え' do
-      subject
       click_button('新しい投稿順')
       sleep 1
       expect(first('.content')).to have_content '5番目の投稿'
     end
 
     example 'いいね多い順への切り替え' do
-      subject
+      click_button('いいね多い順')
+      sleep 1
+      expect(first('.content')).to have_content '1番目の投稿'
+    end
+  end
+
+  context 'ログインしていない時' do
+    before do
+      visit(root_path)
+    end
+
+    example '最初は新しい投稿順に表示されている' do
+      expect(first('.content')).to have_content '5番目の投稿'
+    end
+
+    example '新しい投稿順への切り替え' do
+      click_button('新しい投稿順')
+      sleep 1
+      expect(first('.content')).to have_content '5番目の投稿'
+    end
+
+    example 'いいね多い順への切り替え' do
       click_button('いいね多い順')
       sleep 1
       expect(first('.content')).to have_content '1番目の投稿'


### PR DESCRIPTION
◼️記事の表示順を切り替えるボタンを追加

・投稿が新しい順、いいねが多い順に切り替え可能
・全ジャンル、単一ジャンル選択時、どちらにも対応
・ログインしている時としていない時、どちらにも対応