### PR TITLE
Make it possible to display comment count

### DIFF
--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -31,9 +31,14 @@
           <% @article = article %>
           <% @user = current_user %>
           <div class="comment-button">
-            <%= react_component('comment_button',
-                                 article_id: @article.id,
-                                 user: @user) %> 
+            <div class="d-inline-block">
+              <%= react_component('comment_button',
+                                   article_id: @article.id,
+                                   user: @user) %>
+            </div>
+            <div class="d-inline-block">
+              <span><%= article.comments.all.count %></span>
+            </div>
           </div>
           <div class="stock-button">
             <%= react_component('stock_button',


### PR DESCRIPTION
◼️記事のコメント総数を表示できるようにした

・react側ではコメント総数に関与していないので、
erb側でコメント総数を取得し、d-inline-blockクラスを用いて
コメントボタンの隣にコメント総数を表示できるようにした。