### PR TITLE
Article index

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -52,18 +52,6 @@ class ArticlesController < ApplicationController
     end
   end
 
-  def index
-    session[:for_article_show] = 0
-
-    option = set_option
-    display_order_change(option, PER, params[:genre])
-
-    respond_to do |format|
-      format.html { render 'static_pages/home' }
-      format.json { render json: nil }
-    end
-  end
-
   def destroy
     @article = Article.find(params[:id])
     @article.destroy

--- a/app/controllers/concerns/display_order.rb
+++ b/app/controllers/concerns/display_order.rb
@@ -18,7 +18,7 @@ module DisplayOrder
     end
   end
 
-  def display_order_change(option, per, genre = '')
+  def display_order_change(option, per, genre)
     articles = if genre.present?
                  Article.where(genre: genre)
                else

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -3,25 +3,19 @@
 class StaticPagesController < ApplicationController
   include DisplayOrder
 
-  before_action :use_turbolinks_visit_control
-
   PER = 5
 
   def home
     session[:for_article_show] = 0
 
     option = set_option
-    display_order_change(option, PER)
+    genre ||= params[:genre]
+
+    display_order_change(option, PER, genre)
 
     respond_to do |format|
       format.html {}
       format.json { render json: nil }
     end
-  end
-
-  private
-
-  def use_turbolinks_visit_control
-    @use_turbolinks_visit_control = true
   end
 end

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,0 +1,1 @@
+<%= render '/static_pages/home' %>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,1 +1,0 @@
-<%= render '/static_pages/home' %>

--- a/app/views/shared/_category.html.erb
+++ b/app/views/shared/_category.html.erb
@@ -1,18 +1,17 @@
-<!-- サイドバーを固定したい -->
 <div class="sidebar">
   <span class="category">カテゴリー</span>
   <ul>
     <li><%= link_to '全て', root_path,
             class:"genre_list" %></li>
-    <li><%= link_to 'チョコレート', articles_path(genre: 'chocolate'),
+    <li><%= link_to 'チョコレート', root_path(genre: 'chocolate'),
             class:"genre_list" %></li>
-    <li><%= link_to 'クッキー', articles_path(genre: 'cookie'),
+    <li><%= link_to 'クッキー', root_path(genre: 'cookie'),
             class:"genre_list" %></li>
-    <li><%= link_to 'アイスクリーム', articles_path(genre: 'ice_cream'),
+    <li><%= link_to 'アイスクリーム', root_path(genre: 'ice_cream'),
             class:"genre_list" %></li>
-    <li><%= link_to 'ケーキ', articles_path(genre: 'cake'),
+    <li><%= link_to 'ケーキ', root_path(genre: 'cake'),
             class:"genre_list" %></li>
-    <li><%= link_to 'その他', articles_path(genre: 'etc'),
+    <li><%= link_to 'その他', root_path(genre: 'etc'),
             class:"genre_list" %></li>
   </ul>
 </div>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -37,24 +37,41 @@
   </div>
 </div>
 <script>
-  $(window).on('load', function(){
+  $(document).on('turbolinks:load', function() {
     const button = $('#changing_display_order_button');
     const naviParent = $('#naviParent');
     const navbar = $('.navbar');
     const sidebar = $('.sidebar');
     
-    const offset = button.offset();
+    function initialize()
+    {
+      let d = new $.Deferred;
+
+      button.removeClass('fixed_button');
+      naviParent.removeClass('fixed_naviParent');
+      sidebar.removeClass('fixed_sidebar');
+      scrollTo(0, 0);
+
+      d.resolve();
+      return d.promise();
+    }
     
-    $(window).scroll(function () {
-      if($(window).scrollTop() >= (offset.top - navbar.outerHeight() - 20.0)) {
-        button.addClass('fixed_button');
-        naviParent.addClass('fixed_naviParent');
-        sidebar.addClass('fixed_sidebar')
-      } else {
-        button.removeClass('fixed_button');
-        naviParent.removeClass('fixed_naviParent');
-        sidebar.removeClass('fixed_sidebar')
-      }
+    const promise = initialize();
+
+    promise.then(function(){
+      const offset = button.offset();
+
+      $(window).scroll(function () {
+        if($(window).scrollTop() >= (offset.top - navbar.outerHeight() - 20.0)) {
+          button.addClass('fixed_button');
+          naviParent.addClass('fixed_naviParent');
+          sidebar.addClass('fixed_sidebar')
+        } else {
+          button.removeClass('fixed_button');
+          naviParent.removeClass('fixed_naviParent');
+          sidebar.removeClass('fixed_sidebar');
+        }
+      });
     });
   });
 </script>


### PR DESCRIPTION
◼️ジャンルごとの記事表示を
・articles#index → static_pages#home に
params[:genre]を渡す処理に変更

上記変更により、ジャンル選択ごとにhomeアクションにて
viewを作成(render メソッドを使用しない)し、
home.html.erb内のscriptが実行されるようにした。

・ブラウザバックした場合にscriptの影響でviewが崩れてしまうバグを修正