### PR TITLE
Fix header view

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -93,6 +93,11 @@ body{
     z-index: 1;
 }
 
+/* ヘッダー */
+.header-item{
+    text-decoration: underline;
+}
+
 /** 記事一覧 **/
 .articles ul,
 .article ul,

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -2,19 +2,20 @@
   <div class="container" data-turbolinks="false">
     <%= link_to 'Sweet-Share', root_path, class:"navbar-brand" %>
     <ul class="navbar-nav">
-      <li class="nav-item"><%= link_to "ホーム", root_path, class:"nav-link" %></li>
-      <li class="nav-item"><%= link_to "新規登録", '/users/new', class:"nav-link" %></li>
+      <li class="nav-item">
+        <%= link_to "ホーム", root_path, class:"nav-link header-item" %>
+      </li>
+      <li class="nav-item">
+        <%= link_to "新規登録", '/users/new', class:"nav-link header-item" %>
+      </li>
       <% if logged_in? %>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href='#' id="navbarDropdownMenu"
-          data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">アカウント</a>
-          <div class="dropdown-menu" aria-labelledby="navbarDropdownMenu">
-            <%= link_to "プロフィール", user_path(current_user), class:"dropdown-item" %>
-            <%= link_to "ログアウト", logout_path, method: :delete, class:"dropdown-item" %>
-          </div>
+        <li class="nav-item">
+          <%= link_to "マイページ", user_path(current_user), class:"nav-link header-item" %>
         </li>
       <% else %>
-        <li class="nav-item"><%= link_to "ログイン", '/login', class:"nav-link" %></li>
+        <li class="nav-item">
+          <%= link_to "ログイン", '/login', class:"nav-link header-item" %>
+        </li>
       <% end %>
     </ul>
   </div>

--- a/app/views/shared/_article_user_profile.html.erb
+++ b/app/views/shared/_article_user_profile.html.erb
@@ -25,6 +25,7 @@
     </li>
     <li><%= link_to "ストック記事", stocks_user_path(user), class:"btn btn-primary" %></li>
     <li><%= link_to "プロフィール変更", edit_user_path(user), class:"btn btn-primary" %></li>
+    <li><%= link_to "ログアウト", logout_path, method: :delete, class:"btn btn-primary" %></li>
     <li><%= link_to "アカウント削除", deactivate_user_path(user), class:"btn btn-primary" %></li>
   </ul>
 <% end %>

--- a/app/views/shared/_user_profile.html.erb
+++ b/app/views/shared/_user_profile.html.erb
@@ -26,6 +26,7 @@
     </li>
     <li><%= link_to "ストック記事", stocks_user_path(user), class:"btn btn-primary" %></li>
     <li><%= link_to "プロフィール変更", edit_user_path(user), class:"btn btn-primary" %></li>
+    <li><%= link_to "ログアウト", logout_path, method: :delete, class:"btn btn-primary" %></li>
     <li><%= link_to "アカウント削除", deactivate_user_path(user), class:"btn btn-primary" %></li>
   </ul>
 <% end %>


### PR DESCRIPTION
◼️ヘッダーviewの修正

・ログイン時にヘッダーの右端項目を「マイページ」に変更
・ブランド以外の項目にはアンダーラインを追加
・「ログアウト」ボタンをユーザーページに移動した