### PR TITLE
Follow count

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -134,6 +134,16 @@ body{
     }
 
 /** ユーザーページ機能 **/
+.user-contents{
+    padding-left: 20px;
+}
+
+.follow-info{
+    display: inline-block;
+    padding: 10px 0;
+    font-size: 87%;
+}
+
 .user_profile{
     padding: 0px;
     .btn-primary{

--- a/app/views/shared/_user_function.html.erb
+++ b/app/views/shared/_user_function.html.erb
@@ -2,6 +2,7 @@
   <li><%= link_to image_tag(image, alt: 'User_image', class:'user_image'), user %></li>
   <li><p><%= link_to user.name, user %></p></li>
 </ul>
+<span>フォロー <%= user.followings.count %>&emsp;フォロワー <%= user.followers.count %></span>
 
 <% if current_user?(user) %>
   <!-- 自分の記事がいいねされていて、かつそのcreated_atがlast_access_time より前であること -->

--- a/app/views/shared/_user_function.html.erb
+++ b/app/views/shared/_user_function.html.erb
@@ -1,24 +1,26 @@
-<ul>
-  <li><%= link_to image_tag(image, alt: 'User_image', class:'user_image'), user %></li>
-  <li><p><%= link_to user.name, user %></p></li>
-</ul>
-<span>フォロー <%= user.followings.count %>&emsp;フォロワー <%= user.followers.count %></span>
+<div class="user-contents">
+  <div><%= link_to image_tag(image, alt: 'User_image', class:'user_image'), user %></div>
+  <div><%= link_to user.name, user %></div>
+  <span class="follow-info">
+    フォロー <%= user.followings.count %>&emsp;フォロワー <%= user.followers.count %>
+  </span>
 
-<% if current_user?(user) %>
-  <!-- 自分の記事がいいねされていて、かつそのcreated_atがlast_access_time より前であること -->
-  <% number_of_notice = Like.where(liked_article_id: Article.where(user_id: user.id))
-                            .where("created_at > ?", user.last_access_time).count.to_s.tr('0-9', '０-９') %>
-  <% number_of_notice = '' if number_of_notice == '０' %>
-  <ul class="user-function">
-    <li><%= link_to "記事投稿", new_article_path, class:"btn btn-primary" %></li>
-    <li>
-      <%= link_to notify_user_path(user), class:"btn btn-primary" do %>
-        通知 <span class="rounded-circle bg-danger number_of_notice"><%= "#{number_of_notice}" %></span>
-      <% end %>
-    </li>
-    <li><%= link_to "ストック記事", stocks_user_path(user), class:"btn btn-primary", id:"stock" %></li>
-    <li><%= link_to "プロフィール変更", edit_user_path(user), class:"btn btn-primary", id:"change-profile" %></li>
-    <li><%= link_to "ログアウト", logout_path, method: :delete, class:"btn btn-primary", id:"logout" %></li>
-    <li><%= link_to "アカウント削除", deactivate_user_path(user), class:"btn btn-primary", id:"deactivate" %></li>
-  </ul>
-<% end %>
+  <% if current_user?(user) %>
+    <!-- 自分の記事がいいねされていて、かつそのcreated_atがlast_access_time より前であること -->
+    <% number_of_notice = Like.where(liked_article_id: Article.where(user_id: user.id))
+                              .where("created_at > ?", user.last_access_time).count.to_s.tr('0-9', '０-９') %>
+    <% number_of_notice = '' if number_of_notice == '０' %>
+    <div class="user-function">
+      <div><%= link_to "記事投稿", new_article_path, class:"btn btn-primary" %></div>
+      <div>
+        <%= link_to notify_user_path(user), class:"btn btn-primary" do %>
+          通知 <span class="rounded-circle bg-danger number_of_notice"><%= "#{number_of_notice}" %></span>
+        <% end %>
+      </div>
+      <div><%= link_to "ストック記事", stocks_user_path(user), class:"btn btn-primary", id:"stock" %></div>
+      <div><%= link_to "プロフィール変更", edit_user_path(user), class:"btn btn-primary", id:"change-profile" %></div>
+      <div><%= link_to "ログアウト", logout_path, method: :delete, class:"btn btn-primary", id:"logout" %></div>
+      <div><%= link_to "アカウント削除", deactivate_user_path(user), class:"btn btn-primary", id:"deactivate" %></div>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
◼️ユーザーページにフォロー数、フォロワー数表示追加

・イメージ画像や各種機能ボタンがul, liタグにてpadding-leftが設定されてしまっていたため、
フォロー情報も含めて綺麗に左右中央揃えにできるよう、ul, liタグを削除した。