### PR TITLE
Make sure showing button when not logged in

### DIFF
--- a/app/javascript/components/follow_button.jsx
+++ b/app/javascript/components/follow_button.jsx
@@ -2,8 +2,8 @@ import React, { useState } from "react"
 import classnames from 'classnames'
 
 function FollowButton(props) {
-  const [followUserID, setFollowUserID] = useState(props.follow_user.id)
-  const [followedUserID, setFollowedUserID] = useState(props.followed_user.id)
+  const [followUserID, setFollowUserID] = useState(props.follow_user_id)
+  const [followedUserID, setFollowedUserID] = useState(props.followed_user_id)
   const [relationshipID, setRelationshipID] = useState(props.relationship_id)
   const [followings, setFollowings] = useState(props.followings)
   const [followers, setFollowers] = useState(props.followers)

--- a/app/views/shared/_user_function.html.erb
+++ b/app/views/shared/_user_function.html.erb
@@ -3,8 +3,8 @@
   <div><%= link_to user.name, user %></div>
   <div class="follow-button">
     <%= react_component('follow_button',
-                        follow_user: current_user,
-                        followed_user: user,
+                        follow_user_id: current_user&.id,
+                        followed_user_id: user&.id,
                         relationship_id: current_user &. active_relationships &. find_by(followed_id: user.id)&.id,
                         followings: user &. active_relationships &. all.count,
                         followers: user &. passive_relationships &. all.count ) %>

--- a/public/packs/manifest.json
+++ b/public/packs/manifest.json
@@ -1,6 +1,6 @@
 {
-  "application.js": "/packs/application-c3840e863c2e2b4dd5ff.js",
-  "application.js.map": "/packs/application-c3840e863c2e2b4dd5ff.js.map",
-  "server_rendering.js": "/packs/server_rendering-d0c1dda24f1d7a4561e1.js",
-  "server_rendering.js.map": "/packs/server_rendering-d0c1dda24f1d7a4561e1.js.map"
+  "application.js": "/packs/application-ec00b10b0ecd1002776a.js",
+  "application.js.map": "/packs/application-ec00b10b0ecd1002776a.js.map",
+  "server_rendering.js": "/packs/server_rendering-997c3362faec5e4776ef.js",
+  "server_rendering.js.map": "/packs/server_rendering-997c3362faec5e4776ef.js.map"
 }


### PR DESCRIPTION
◼️非ログイン時に作成記事を表示すると記事内のボタンやフォローボタンが表示されないバグを解消

・原因
follow_button.jsx 5, 6行目
follow_user, followed_userがnullであった時に、
nullのidプロパティを取得しようとしてエラーになり
コンポーネントが表示されなくなってしまっていた
（デベロッパーツールのコンソールログにて確認）

・対応
_user_function.html.erb側でぼっち演算子を使用し、
follow_user, followed_userが入ればそのid,いなければnullをReact側に渡すこととした