### PR TITLE
Fix option

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -29,14 +29,8 @@ class StaticPagesController < ApplicationController
 
   # 記事表示順選択用オプションをセット
   def set_option
-    if current_user
-      current_user.update(order_option: params[:option]) if params[:option]
-      current_user.order_option
-    else
-      # ログインしていない時はオプションをセッションに格納
-      session[:not_logged_in] = 0                    if session[:not_logged_in].nil?
-      session[:not_logged_in] = params[:option].to_i if params[:option]
-      session[:not_logged_in]
-    end
+    session[:option] = 0                    if session[:option].nil?
+    session[:option] = params[:option].to_i if params[:option]
+    session[:option]
   end
 end

--- a/app/javascript/components/changing_display_order_button.jsx
+++ b/app/javascript/components/changing_display_order_button.jsx
@@ -62,7 +62,7 @@ function ChangingDisplayOrderButton(props){
     )
   }
   
-  const orderByCreatedAtAsk = () =>{
+  const orderByLikesDesk = () =>{
     const [type, opt] = setInfo(url, 1)
     
     setOpt(opt)
@@ -88,7 +88,7 @@ function ChangingDisplayOrderButton(props){
           </button>
           <button
             className={ option === 0 ? secondaryButton : primaryButton }
-            onClick={ () => orderByCreatedAtAsk() }
+            onClick={ () => orderByLikesDesk() }
             disabled={ loading }
           >
             いいね多い順

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -8,11 +8,7 @@
   <div id="naviParent">
     <div class="row" id="changing_display_order_button">
       <div class="col-md-6 offset-md-3">
-        <% if current_user %>
-          <% option = current_user.order_option %>
-        <% else %>
-          <% option = session[:not_logged_in] %>
-        <% end %>
+        <% option = session[:option] %>
         <div>
           <%= react_component('changing_display_order_button', option: option) %>
         </div>

--- a/db/migrate/20200415021852_remove_order_option_from_users.rb
+++ b/db/migrate/20200415021852_remove_order_option_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveOrderOptionFromUsers < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :users, :order_option, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200402015209) do
+ActiveRecord::Schema.define(version: 20200415021852) do
 
   create_table "articles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "content", null: false
@@ -76,7 +76,6 @@ ActiveRecord::Schema.define(version: 20200402015209) do
     t.string "remember_digest"
     t.string "image"
     t.datetime "last_access_time", default: "1900-01-01 00:00:00"
-    t.integer "order_option", default: 0, null: false
     t.boolean "for_test", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end

--- a/public/packs/manifest.json
+++ b/public/packs/manifest.json
@@ -1,6 +1,6 @@
 {
-  "application.js": "/packs/application-ec00b10b0ecd1002776a.js",
-  "application.js.map": "/packs/application-ec00b10b0ecd1002776a.js.map",
-  "server_rendering.js": "/packs/server_rendering-997c3362faec5e4776ef.js",
-  "server_rendering.js.map": "/packs/server_rendering-997c3362faec5e4776ef.js.map"
+  "application.js": "/packs/application-d3b1e63a79fe5e144e69.js",
+  "application.js.map": "/packs/application-d3b1e63a79fe5e144e69.js.map",
+  "server_rendering.js": "/packs/server_rendering-6423e47285bd57a26c77.js",
+  "server_rendering.js.map": "/packs/server_rendering-6423e47285bd57a26c77.js.map"
 }


### PR DESCRIPTION
◼️記事表示順切り替え用パラメータ(option)に関する修正

・ログイン時と非ログイン時でoptionの設定手法が異なっていたが、
どちらも統一でsessionのハッシュで設定することとした

理由：
テストユーザーとしてサイト利用時は、以前の仕様では
テストユーザーのorder_optionカラムでオプションをセットしていたが、
テストユーザーは複数のユーザーが同時に利用する可能性があり、
あるユーザーのオプション設定変更が他ユーザーにも適用されてしまう
可能性があった。
そのため、ユーザーごとで管理できるsessionのハッシュ内で
管理することとした。