### PR TITLE
Don't show error message

### DIFF
--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -63,8 +63,6 @@
                       map: map,
                       position: results[0].geometry.location
                     });
-                  } else {
-                    alert('Geocode was not successful for the following reason: ' + status);
                   }
                 });
               }


### PR DESCRIPTION
◼️エラーメッセージを表示させないようにした

・スマホで戻るボタンを押してホーム画面に戻る際にエラーメッセージが表示されてしまうため、一旦エラーメッセージを表示させないようにした。これで不具合あれば一旦マージ取り消し予定