### PR TITLE
Switch options

### DIFF
--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -46,7 +46,7 @@
             </div>
             <script>
               $(document).on('turbolinks:load', function() {
-                const geocoder = new google.maps.Geocoder()
+                const geocoder = new google.maps.Geocoder();
 
                 const map = new google.maps.Map(document.getElementById('map-<%= article.id %>'), {
                 center: {lat: -34.397, lng: 150.644},
@@ -62,6 +62,21 @@
                     const marker = new google.maps.Marker({
                       map: map,
                       position: results[0].geometry.location
+                    });
+                  }
+                });
+                $(window).resize(function() {
+                  if(document.getElementById('map-<%= article.id %>').clientWidth <= 400){
+                    map.setOptions({
+                      mapTypeControl: false,
+                      streetViewControl: false,
+                      zoomControl: false
+                    });
+                  }else{
+                    map.setOptions({
+                      mapTypeControl: true,
+                      streetViewControl: true,
+                      zoomControl: true
                     });
                   }
                 });

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -47,10 +47,11 @@
             <script>
               $(document).on('turbolinks:load', function() {
                 const geocoder = new google.maps.Geocoder();
+                const mapArea = document.getElementById('map-<%= article.id %>')
 
-                const map = new google.maps.Map(document.getElementById('map-<%= article.id %>'), {
-                center: {lat: -34.397, lng: 150.644},
-                zoom: 12
+                const map = new google.maps.Map(mapArea, {
+                  center: {lat: -34.397, lng: 150.644},
+                  zoom: 12
                 });
 
                 const inputAddress = document.getElementById('address-<%= article.id %>').textContent;
@@ -66,7 +67,7 @@
                   }
                 });
                 $(window).resize(function() {
-                  if(document.getElementById('map-<%= article.id %>').clientWidth <= 400){
+                  if(mapArea.clientWidth <= 400){
                     map.setOptions({
                       mapTypeControl: false,
                       streetViewControl: false,


### PR DESCRIPTION
◼️画面幅によるGoogle Mapオプションの切り替え

・画面横幅が狭くなるとオプションのUIでマップの可視範囲が狭まるため、
　マップ幅が400px以下となった時に複数オプションを使用不可とした。