### PR TITLE
Don't show option UI when display width is narrow

### DIFF
--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -54,6 +54,14 @@
                   zoom: 12
                 });
 
+                if(mapArea.clientWidth <= 400){
+                  map.setOptions({
+                    mapTypeControl: false,
+                    streetViewControl: false,
+                    zoomControl: false
+                  });
+                }
+
                 const inputAddress = document.getElementById('address-<%= article.id %>').textContent;
 
                 geocoder.geocode( { 'address': inputAddress}, function(results, status) {


### PR DESCRIPTION
◼️画面幅が狭い（スマホ幅程度）時はGoogle Mapのオプション機能を表示させないようにした