### PR TITLE
Add margin-bottom to sidebar

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -158,6 +158,7 @@
 
 .sidebar{
     padding-left: 30px;
+    margin-bottom: 30px;
 }
 
 .fixed_sidebar {


### PR DESCRIPTION
◼️サイドバーの下にmargin-bottomを追加
（レスポンシブデザインでサイドバーと記事一覧が1列で表示される時にサイドバーと記事の間隔が狭かったため）