### PR TITLE
Fix article view

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -578,7 +578,7 @@
 
 /* Google マップ */
 div[id^="map-"]{
-    height: 300px;
+    height: 200px;
 }
 
 @media screen and (max-width:429px) {

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -587,12 +587,12 @@ div[id^="map-"]{
     }
 }
 
-p.content{
-    margin-bottom: 0px;
+.content .col-2{
+    padding-right: 0px;
 }
 
-div.content{
-    padding: 2px 0;
+p.content{
+    margin-bottom: 0px;
 }
 
 /* コメント内容 */

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -588,7 +588,6 @@ div[id^="map-"]{
 }
 
 p.content{
-    margin-left: 5px;
     margin-bottom: 0px;
 }
 

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -531,8 +531,11 @@
     &-item{
         color: black;
     }
-    &-content{
+    &-content-area{
         margin-right: 25px;
+    }
+    &-content{
+        word-wrap: break-word;
     }
     &-padding{
         padding: 5px 0;
@@ -556,7 +559,7 @@
     }
 }
 
-.article-content .article-sweet-image{
+.article-content-area .article-sweet-image{
     &:hover{
         border: 2px solid blue;
     }
@@ -570,11 +573,15 @@
     .article-user{
         font-size: 1.0rem;
     }
+    .article-content-area{
+        font-size: 0.8rem;
+    }
 }
 
-.url-table{
+.content-table{
     table-layout: fixed;
     width: 100%;
+    line-height: 170%;
 }
 
 .url{

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -530,6 +530,7 @@
     border-radius: 9px;
     &-item{
         color: black;
+        width: 80px;
     }
     &-content-area{
         margin-right: 25px;
@@ -569,15 +570,6 @@
     margin-top: 10px;
 }
 
-@media screen and (max-width:375px) {
-    .article-user{
-        font-size: 1.0rem;
-    }
-    .article-content-area{
-        font-size: 0.8rem;
-    }
-}
-
 .content-table{
     table-layout: fixed;
     width: 100%;
@@ -586,6 +578,27 @@
 
 .url{
     font-size: 0.9rem;
+}
+
+@media screen and (max-width:429px) {
+    .article-sweet-image{
+        height: 170px;
+    }
+}
+
+@media screen and (max-width:375px) {
+    .article-user{
+        font-size: 1.0rem;
+    }
+    .article-content-area{
+        font-size: 0.8rem;
+    }
+    .article-item{
+        width: 70px;
+    }
+    .url{
+        font-size: 0.7rem;
+    }
 }
 
 /* Google マップ */

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -591,11 +591,12 @@
 /* Google マップ */
 div[id^="map-"]{
     height: 200px;
+    margin: 6px 0;
 }
 
 @media screen and (max-width:429px) {
     div[id^="map-"]{
-        height: 200px;
+        height: 170px;
     }
 }
 

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -528,6 +528,9 @@
     border-bottom: solid 4px #DDDDDD;
     box-shadow: 0 3px 6px rgba(0, 0, 0, 0.25);
     border-radius: 9px;
+    &-item{
+        color: black;
+    }
     &-content{
         margin-right: 25px;
     }

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -572,8 +572,13 @@
     }
 }
 
+.url-table{
+    table-layout: fixed;
+    width: 100%;
+}
+
 .url{
-    word-wrap: break-word;
+    font-size: 0.9rem;
 }
 
 /* Google マップ */

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -6,7 +6,7 @@
         <%= link_to image_tag(image(user), alt: 'User_image', class:'user_image'), user, class:'upper-link' %>
       </div>
       <div class="col-9 no_padding">
-        <div class="article-content">
+        <div class="article-content-area">
           <div class="article-padding">
             <span class="article-user"><%= link_to user.name, user, class:'upper-link' %></span>
             <span class="article-timestamp">
@@ -18,39 +18,33 @@
               <%= image_tag article.image, class: 'article-sweet-image upper-link' %>
             <% end %>
           <% end %>
-          <% if article.shop.present? %>
-            <!--<div class="article-padding">-->
-              <table>
-                <tr>
-                  <td class="article-item" width="80px">店名</td>
-                  <td><%= article.shop %></td>
-                </tr>
-              </table>
-            <!--</div>-->
-          <% end %>
-          <table>
-            <tr>
-              <td class="article-item" width="80px">商品名</td>
-              <td><%= article.sweet_name %></td>
-            </tr>
-            <tr>
-              <td class="article-item" width="80px">ジャンル</td>
-              <td><%= article.converted_genre %></td>
-            </tr>
-          </table>
-          <% if article.url.present? %>
-            <table class="url-table">
+          <table class="content-table">
+            <% if article.shop.present? %>
               <tr>
-                <td class="article-item" width="80px">URL</td>
-                <td style="word-wrap: break-word;"><a href="<%= article.url %>" target="_blank" class="upper-link url"><%= article.url %></a></td>
+                <td class="article-item" width="80px" valign="top">店名</td>
+                <td class="article-content"><%= article.shop %></td>
               </tr>
-            </table>
-          <% end %>
-          <% if article.prefecture.present? %>
-            <table>
+            <% end %>
+            <tr>
+              <td class="article-item" width="80px" valign="top">商品名</td>
+              <td class="article-content"><%= article.sweet_name %></td>
+            </tr>
+            <tr>
+              <td class="article-item" width="80px" valign="top">ジャンル</td>
+              <td class="article-content"><%= article.converted_genre %></td>
+            </tr>
+            <% if article.url.present? %>
               <tr>
-                <td class="article-item" width="80px">住所</td>
-                <td id="address-<%= article.id %>"><%= article.arranged_address %></td>
+                <td class="article-item" width="80px" valign="top">URL</td>
+                <td class="article-content"><a href="<%= article.url %>" target="_blank" class="upper-link url"><%= article.url %></a></td>
+              </tr>
+            <% end %>
+          </table>
+          <% if article.prefecture.present? %>
+            <table class="content-table">
+              <tr>
+                <td class="article-item" width="80px" valign="top">住所</td>
+                <td class="article-content" id="address-<%= article.id %>"><%= article.arranged_address %></td>
               </tr>
             </table>
             <div class='upper-link' id='map-<%= article.id %>'>
@@ -103,10 +97,10 @@
               });
             </script>
           <% end %>
-          <table>
+          <table class="content-table">
             <tr>
-              <td class="article-item" width="80px">紹介文</td>
-              <td><%= article.content %></td>
+              <td class="article-item" width="80px" valign="top">紹介文</td>
+              <td class="article-content"><%= article.content %></td>
             </tr>
           </table>
         </div>

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -107,14 +107,12 @@
             </script>
           <% end %>
           <div class="article-padding">
-            <div class="row">
+            <div class="row content">
               <div class="col-2">
                 <span class="article-item content">紹介文</span>
               </div>
               <div class="col-10">
-                <div class="content">
-                  <p class="content"><%= article.content %></p>
-                </div>
+                <p class="content"><%= article.content %></p>
               </div>
             </div>
           </div>

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -21,21 +21,21 @@
           <table class="content-table">
             <% if article.shop.present? %>
               <tr>
-                <td class="article-item" width="80px" valign="top">店名</td>
+                <td class="article-item" valign="top">店名</td>
                 <td class="article-content"><%= article.shop %></td>
               </tr>
             <% end %>
             <tr>
-              <td class="article-item" width="80px" valign="top">商品名</td>
+              <td class="article-item" valign="top">商品名</td>
               <td class="article-content"><%= article.sweet_name %></td>
             </tr>
             <tr>
-              <td class="article-item" width="80px" valign="top">ジャンル</td>
+              <td class="article-item" valign="top">ジャンル</td>
               <td class="article-content"><%= article.converted_genre %></td>
             </tr>
             <% if article.url.present? %>
               <tr>
-                <td class="article-item" width="80px" valign="top">URL</td>
+                <td class="article-item" valign="top">URL</td>
                 <td class="article-content"><a href="<%= article.url %>" target="_blank" class="upper-link url"><%= article.url %></a></td>
               </tr>
             <% end %>
@@ -43,7 +43,7 @@
           <% if article.prefecture.present? %>
             <table class="content-table">
               <tr>
-                <td class="article-item" width="80px" valign="top">住所</td>
+                <td class="article-item" valign="top">住所</td>
                 <td class="article-content" id="address-<%= article.id %>"><%= article.arranged_address %></td>
               </tr>
             </table>
@@ -98,7 +98,7 @@
           <% end %>
           <table class="content-table">
             <tr>
-              <td class="article-item" width="80px" valign="top">紹介文</td>
+              <td class="article-item" valign="top">紹介文</td>
               <td class="article-content"><%= article.content %></td>
             </tr>
           </table>

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -65,7 +65,7 @@
 
                 const map = new google.maps.Map(mapArea, {
                   center: {lat: -34.397, lng: 150.644},
-                  zoom: 12
+                  zoom: 14
                 });
 
                 if(mapArea.clientWidth <= 400){

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -19,43 +19,40 @@
             <% end %>
           <% end %>
           <% if article.shop.present? %>
-            <div class="article-padding">
-              <span>
-                <span class="article-item">店名&emsp;&emsp;&emsp;</span><%= article.shop %>
-              </span>
-            </div>
+            <!--<div class="article-padding">-->
+              <table>
+                <tr>
+                  <td class="article-item" width="80px">店名</td>
+                  <td><%= article.shop %></td>
+                </tr>
+              </table>
+            <!--</div>-->
           <% end %>
-          <div class="article-padding">
-            <span>
-              <span class="article-item">商品名&emsp;&emsp;</span><%= article.sweet_name %>
-            </span>
-          </div>
-          <div class="article-padding">
-            <span>
-              <span class="article-item">ジャンル&emsp;</span><%= article.converted_genre %>
-            </span>
-          </div>
+          <table>
+            <tr>
+              <td class="article-item" width="80px">商品名</td>
+              <td><%= article.sweet_name %></td>
+            </tr>
+            <tr>
+              <td class="article-item" width="80px">ジャンル</td>
+              <td><%= article.converted_genre %></td>
+            </tr>
+          </table>
           <% if article.url.present? %>
-            <div class="article-padding url">
-              <div class="row">
-                <div class="col-2">
-                  <span class="article-item">URL</span>
-                </div>
-                <div class="col-10">
-                  <span class="url">
-                    <a href="<%= article.url %>" target="_blank" class="upper-link"><%= article.url %></a>
-                  </span>
-                </div>
-              </div>
-            </div>
+            <table class="url-table">
+              <tr>
+                <td class="article-item" width="80px">URL</td>
+                <td style="word-wrap: break-word;"><a href="<%= article.url %>" target="_blank" class="upper-link url"><%= article.url %></a></td>
+              </tr>
+            </table>
           <% end %>
           <% if article.prefecture.present? %>
-            <div class="article-padding">
-              <span>
-                <span class="article-item">住所&emsp;&emsp;&emsp;</span>
-                <span id="address-<%= article.id %>"><%= article.arranged_address %></span>
-              </span>
-            </div>
+            <table>
+              <tr>
+                <td class="article-item" width="80px">住所</td>
+                <td id="address-<%= article.id %>"><%= article.arranged_address %></td>
+              </tr>
+            </table>
             <div class='upper-link' id='map-<%= article.id %>'>
             </div>
             <script>
@@ -106,16 +103,12 @@
               });
             </script>
           <% end %>
-          <div class="article-padding">
-            <div class="row content">
-              <div class="col-2">
-                <span class="article-item content">紹介文</span>
-              </div>
-              <div class="col-10">
-                <p class="content"><%= article.content %></p>
-              </div>
-            </div>
-          </div>
+          <table>
+            <tr>
+              <td class="article-item" width="80px">紹介文</td>
+              <td><%= article.content %></td>
+            </tr>
+          </table>
         </div>
 
         <!-- ボタン一覧 -->

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -37,10 +37,16 @@
           </div>
           <% if article.url.present? %>
             <div class="article-padding url">
-              <span class="url">
-                <span class="article-item">参考URL&emsp;</span>
-                <a href="<%= article.url %>" target="_blank" class="upper-link"><%= article.url %></a>
-              </span>
+              <div class="row">
+                <div class="col-2">
+                  <span class="article-item">URL</span>
+                </div>
+                <div class="col-10">
+                  <span class="url">
+                    <a href="<%= article.url %>" target="_blank" class="upper-link"><%= article.url %></a>
+                  </span>
+                </div>
+              </div>
             </div>
           <% end %>
           <% if article.prefecture.present? %>
@@ -101,12 +107,15 @@
             </script>
           <% end %>
           <div class="article-padding">
-            <!--<span class="content">-->
-              <!--<span class="article-item">紹介文&emsp;&emsp;</span>-->
-              <span class="article-item content">紹介文&emsp;&emsp;</span>
-            <!--</span>-->
-            <div class="border rounded content">
-              <p class="content"><%= article.content %></p>
+            <div class="row">
+              <div class="col-2">
+                <span class="article-item content">紹介文</span>
+              </div>
+              <div class="col-10">
+                <div class="content">
+                  <p class="content"><%= article.content %></p>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -59,10 +59,13 @@
                   zoom: 14
                 });
 
+                map.setOptions({
+                  mapTypeControl: false,
+                  streetViewControl: false,
+                });
+
                 if(mapArea.clientWidth <= 400){
                   map.setOptions({
-                    mapTypeControl: false,
-                    streetViewControl: false,
                     zoomControl: false
                   });
                 }
@@ -82,14 +85,10 @@
                 $(window).resize(function() {
                   if(mapArea.clientWidth <= 400){
                     map.setOptions({
-                      mapTypeControl: false,
-                      streetViewControl: false,
                       zoomControl: false
                     });
                   }else{
                     map.setOptions({
-                      mapTypeControl: true,
-                      streetViewControl: true,
                       zoomControl: true
                     });
                   }

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -20,26 +20,34 @@
           <% end %>
           <% if article.shop.present? %>
             <div class="article-padding">
-              <span>店名：<%= article.shop %></span>
+              <span>
+                <span class="article-item">店名&emsp;&emsp;&emsp;</span><%= article.shop %>
+              </span>
             </div>
           <% end %>
           <div class="article-padding">
-            <span>商品名：<%= article.sweet_name %></span>
+            <span>
+              <span class="article-item">商品名&emsp;&emsp;</span><%= article.sweet_name %>
+            </span>
           </div>
           <div class="article-padding">
-            <span>ジャンル：<%= article.converted_genre %></span>
+            <span>
+              <span class="article-item">ジャンル&emsp;</span><%= article.converted_genre %>
+            </span>
           </div>
           <% if article.url.present? %>
             <div class="article-padding url">
               <span class="url">
-                参考URL：<a href="<%= article.url %>" target="_blank" class="upper-link"><%= article.url %></a>
+                <span class="article-item">参考URL&emsp;</span>
+                <a href="<%= article.url %>" target="_blank" class="upper-link"><%= article.url %></a>
               </span>
             </div>
           <% end %>
           <% if article.prefecture.present? %>
             <div class="article-padding">
               <span>
-                住所：<span id="address-<%= article.id %>"><%= article.arranged_address %></span>
+                <span class="article-item">住所&emsp;&emsp;&emsp;</span>
+                <span id="address-<%= article.id %>"><%= article.arranged_address %></span>
               </span>
             </div>
             <div class='upper-link' id='map-<%= article.id %>'>
@@ -93,7 +101,10 @@
             </script>
           <% end %>
           <div class="article-padding">
-            <span class="content">紹介文：</span>
+            <!--<span class="content">-->
+              <!--<span class="article-item">紹介文&emsp;&emsp;</span>-->
+              <span class="article-item content">紹介文&emsp;&emsp;</span>
+            <!--</span>-->
             <div class="border rounded content">
               <p class="content"><%= article.content %></p>
             </div>

--- a/spec/system/article/article_create_spec.rb
+++ b/spec/system/article/article_create_spec.rb
@@ -32,13 +32,17 @@ RSpec.describe '記事投稿時の挙動', type: :system do
 
     example 'ユーザーページに投稿した記事が表示される' do
       subject
-      expect(page).to have_content('商品名：' + article.sweet_name)
+      expect(page).to have_content(article.sweet_name)
+      expect(page).to have_content(article.converted_genre)
+      expect(page).to have_content(article.content)
     end
 
     example 'ルートページに投稿した記事が表示される' do
       subject
       visit(root_path)
-      expect(page).to have_content('商品名：' + article.sweet_name)
+      expect(page).to have_content(article.sweet_name)
+      expect(page).to have_content(article.converted_genre)
+      expect(page).to have_content(article.content)
     end
 
     example '記事レコード数が1増える' do


### PR DESCRIPTION
◼️記事ビューの修正

・記事画像、マップ以外の表示形式を表形式とした
　理由：ディスプレイ幅に関わらず列間隔（項目と内容の間）を一定にできるため

・行間隔の調整

・デザインの変更に伴うテスト内容の修正