### PR TITLE
Remove user_params_including_image method

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -53,7 +53,7 @@ class UsersController < ApplicationController
 
   def update
     @user = User.find(params[:id])
-    if @user.update(user_params_including_image)
+    if @user.update(user_params)
       flash[:success] = 'プロフィールが更新されました'
       redirect_to @user
     else
@@ -100,13 +100,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :email,
-                                 :password, :password_confirmation)
-  end
-
-  # TODO
-  # 新規登録時も以下に更新する?
-  def user_params_including_image
     params.require(:user).permit(:name, :email,
                                  :password, :password_confirmation, :image)
   end


### PR DESCRIPTION
◼️user_params_including_image メソッドを削除

paramsのpermitメソッドは変更を許可する項目を指定するので、指定された項目が必ず渡されなければならない、ということではない。

よって、入力され得る項目を全て網羅したメソッドを1つ用意しておけば良いため、
image も含めた全項目をpermitするメソッドのみにすることとした。